### PR TITLE
Use Enum Utilities + New Response Payload + Fix for example

### DIFF
--- a/zig/examples/build.zig
+++ b/zig/examples/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.build.Builder) void {
     const exe = b.addExecutable("examples", "src/main.zig");
     exe.addPackage(.{
         .name = "khadem",
-        .path = .{ .path = "../src/http.zig" },
+        .source = .{ .path = "../src/http.zig" },
     });
     exe.setTarget(target);
     exe.setBuildMode(mode);

--- a/zig/examples/src/main.zig
+++ b/zig/examples/src/main.zig
@@ -11,6 +11,7 @@ const RouteHandler = khadem.routes.RouteHandler;
 const RouteHandlerFn = khadem.routes.RouteHandlerFn;
 const Router = khadem.routes.Router;
 const LogRequest = khadem.middlewares.LogRequest;
+const Ok = Response.Status.Ok;
 
 pub const io_mode = .evented;
 
@@ -31,8 +32,8 @@ pub fn main() anyerror!void {
     try server.listen();
 }
 fn greetHandler(req: *Request, resp: *Response) anyerror!void {
-    try resp.respond(Response.Status.Ok(), null, req.getQueryParam("name").?);
+    try resp.respond(.{.status = Ok, .body = req.getParam("name").?});
 }
 fn indexHandler(_: *Request, resp: *Response) anyerror!void {
-    try resp.respond(Response.Status.Ok(), null, "index");
+    try resp.respond(.{.status = Ok, .body = "index"});
 }

--- a/zig/src/Request.zig
+++ b/zig/src/Request.zig
@@ -19,36 +19,38 @@ pub const ParsingError = error{
 
 pub const Method = enum {
     GET,
+    DELETE,
+    OPTION,
+    PATCH,
     POST,
     PUT,
-    PATCH,
-    OPTION,
-    DELETE,
     pub fn fromString(s: []const u8) !Method {
-        if (std.mem.eql(u8, "GET", s)) return .GET;
-        if (std.mem.eql(u8, "POST", s)) return .POST;
-        if (std.mem.eql(u8, "PUT", s)) return .PUT;
-        if (std.mem.eql(u8, "PATCH", s)) return .PATCH;
-        if (std.mem.eql(u8, "OPTION", s)) return .OPTION;
-        if (std.mem.eql(u8, "DELETE", s)) return .DELETE;
-        return ParsingError.MethodNotValid;
+        var method = std.meta.stringToEnum(Method, s);
+        if (method) |m| {
+            return m;
+        } else {
+            return ParsingError.MethodNotValid;
+        }
     }
 };
 
 pub const Version = enum {
-    @"1.1",
-    @"2",
-
+    @"HTTP/1.1",
+    @"HTTP/2",
     pub fn fromString(s: []const u8) !Version {
-        if (std.mem.eql(u8, "HTTP/1.1", s)) return .@"1.1";
-        if (std.mem.eql(u8, "HTTP/2", s)) return .@"2";
-        return ParsingError.VersionNotValid;
+        var version = std.meta.stringToEnum(Version, s);
+        if (version) |v| {
+            return v;
+        } else {
+            return ParsingError.VersionNotValid;
+        }
     }
-
-    pub fn asString(self: Version) []const u8 {
-        if (self == Version.@"1.1") return "HTTP/1.1";
-        if (self == Version.@"2") return "HTTP/2";
-        unreachable;
+    pub fn toString(self: Version) []const u8 {
+        var version = switch (self) {
+            .@"HTTP/1.1" => "HTTP/1.1",
+            .@"HTTP/2" => "HTTP/2"
+        };
+        return version;
     }
 };
 

--- a/zig/src/routes.zig
+++ b/zig/src/routes.zig
@@ -3,6 +3,7 @@ const http = @import("http.zig");
 const Handler = http.server.Handler;
 const HandlerFn = Handler.Fn;
 const middleware = @import("middlewares.zig");
+const NotFound = http.Response.Status.NotFound;
 
 const RouteHandlerTuple = struct {
     handler: Handler,
@@ -41,7 +42,7 @@ pub fn Router(comptime route_handlers: []const RouteHandlerTuple) Handler {
                     }
                 }
             }
-            return resp.respond(http.Response.Status.NotFound(), null, "Not Found");
+            return resp.respond(.{.status = NotFound, .body = "Not Found"});
         }
     };
     return Handler.init(comptime dumb.handler);


### PR DESCRIPTION
Updates to use Enum Utilities from Standard Library + Introduced Response Payload + Fix for `/greet/:name` path handler in example.